### PR TITLE
Corrected link text on using file

### DIFF
--- a/docs-content/using.html.md.erb
+++ b/docs-content/using.html.md.erb
@@ -2,4 +2,4 @@
 title: Deploying Pega Platform clusters
 owner: Partners
 ---
-To deploy Pega® Platform clusters on Cloud Foundry, see https://pdn.pega.com/deploying-pega-platform-clusters-cloud-foundry (registration required).
+To deploy Pega® Platform clusters on Cloud Foundry, see [Deploying Pega Platform clusters on Cloud Foundry] https://pdn.pega.com/deploying-pega-platform-clusters-cloud-foundry (registration required).


### PR DESCRIPTION
On the Deploying Pega Platform clusters tab, the link showed the URL rather than the title.