### PR TITLE
Update license info

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -69,4 +69,4 @@ Please provide any bugs, feature requests, or questions to the
 
 ## <a id='license'></a>License
 
-Pega for PCF is freeware.
+Pega for PCF is available at no additional charge and with no additional license requirements to current Pega Platform customers.


### PR DESCRIPTION
Although Pega for PCF is freeware, it is useless without the Pega Platform license.